### PR TITLE
Wait on option

### DIFF
--- a/lib/client/route_controller.js
+++ b/lib/client/route_controller.js
@@ -71,6 +71,11 @@ RouteController = function (context, options) {
     || routeOptions.renderTemplates
     || routerOptions.renderTemplates
     || this.renderTemplates;
+  
+  this.waitOn = options.waitOn
+    || routeOptions.waitOn
+    || routerOptions.waitOn
+    || this.waitOn;
 
   this.stopped = false;
 


### PR DESCRIPTION
I think maybe you just missed this?

This allows you to set `waitOn` at the `.route()` or even `Router.configure` level.
