### PR TITLE
Allow replace state on `.go()`

### DIFF
--- a/lib/client/client_router.js
+++ b/lib/client/client_router.js
@@ -220,34 +220,39 @@ ClientRouter = RouterUtils.extend(IronRouter, {
    * @param {String} routeNameOrPath
    * @param {Array|Object} [params]
    * @param {Object} [state]
+   * @param {Boolean} [replaceState]
    * @api public
    */
 
-  go: function (routeNameOrPath, params, state) {
+  go: function (routeNameOrPath, params, state, replaceState) {
     var isPathRe = /^\/|http/
       , route
       , path
       , state
-      , onComplete;
+      , onComplete
+      , done = function() {
+        if (replaceState) {
+          Location.replaceState(state, null, path, true /* skipReactive */);
+        } else {
+          Location.pushState(state, null, path, true /* skipReactive */);
+        }
+      };
 
     if (isPathRe.test(routeNameOrPath)) {
       path = routeNameOrPath;
       state = params;
+      replaceState = state;
       // issue here is in the dispatch process we might want to
       // make a server request so therefore not call this method yet, so
       // we need to push the state only after we've decided it's a client
       // request, otherwise let the browser handle it and send off to the
       // server
-      this.dispatch(path, {state: state}, function () {
-        Location.pushState(state, null, path, true /* skipReactive */);
-      });
+      this.dispatch(path, {state: state}, done);
     } else {
       route = this.routes[routeNameOrPath];
       RouterUtils.assert(route, 'No route found named ' + routeNameOrPath);
       path = route.path(params);
-      this.run(path, route, {state: state}, function () {
-        Location.pushState(state, null, path, true /* skipReactive */);
-      });
+      this.run(path, route, {state: state}, done);
     }
   },
 

--- a/lib/client/location.js
+++ b/lib/client/location.js
@@ -94,9 +94,9 @@ Location = {
    * @api public
    */
 
-  replaceState: function (state, title, url) {
+  replaceState: function (state, title, url, skipReactive) {
     history.replaceState(state, title, url);
-    this._setState(state, title, url);
+    this._setState(state, title, url, skipReactive);
   },
 
   /**


### PR DESCRIPTION
Ok, last one, I promise :)

This is useful if you are using `Location.back()` in your app. Probably there should be some way to mark links as "replacers" but I'm good with this for now.

I'm not sure if it's the best API ever..
