### PR TITLE
don't route on same url

### DIFF
--- a/lib/client/client_router.js
+++ b/lib/client/client_router.js
@@ -165,7 +165,7 @@ ClientRouter = RouterUtils.extend(IronRouter, {
         function renderPartial () {
           var partial = self._partials.get(key);
           RouterUtils.assert(
-            partial, 
+            partial,
             'No yield named "' + key + '" found. Are you sure it\'s in your main layout template?'
           );
           return partial.render();
@@ -218,7 +218,7 @@ ClientRouter = RouterUtils.extend(IronRouter, {
     //XXX listener.installHandler(node, type) for A tags and children to make
     //work with IE<8
     self._eventListener.addType('click');
-    
+
     Deps.autorun(function (c) {
       var state;
       self._locationComputation = c;
@@ -266,6 +266,9 @@ ClientRouter = RouterUtils.extend(IronRouter, {
 
       event.stopImmediatePropagation();
       event.preventDefault();
+
+      if(el.href == location.href)
+        return;
 
       this.go(path);
     }


### PR DESCRIPTION
Router is re-rendering whole page when click on links with empty hrefs. I think router shouldn't re-render for current url.
