### PR TITLE
allow non-reactive reads of current route

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -353,11 +353,15 @@ IronRouter.prototype = {
   /**
    * Reactive accessor for the current context.
    *
+   * @param {Object} [opts] configuration options
+   * @param {Boolean} [opts.reactive] Set to false to enable a non-reactive read.
    * @return {RouteContext}
    * @api public
    */
 
-  current: function () {
+  current: function (opts) {
+    if(opts && opts.reactive === false) return this._current;
+    
     this._deps.depend();
     return this._current;
   },


### PR DESCRIPTION
It's useful for me to be able to read the current route non-reactively. I thought others might find that ability useful as well. Let me know what you think of this change. Used `{reactive: false}` for parity with Collection finds.
