### PR TITLE
Removed 'event.stopImmediatePropagation();' from onClick event handler.

### DIFF
--- a/lib/client/client_router.js
+++ b/lib/client/client_router.js
@@ -272,7 +272,6 @@ ClientRouter = RouterUtils.extend(IronRouter, {
       if (!Location.isSameOrigin(href))
         return;
 
-      event.stopImmediatePropagation();
       event.preventDefault();
 
       this.go(path);


### PR DESCRIPTION
Only need 'preventDefault' to stop the browser following the link.

removed 'stopImmediatePropagation' as it breaks bootstrap menus, or anything else that listens to click events on anchor tags.
