### PR TITLE
Allow handles to be inherited properly.

### DIFF
--- a/lib/client/route_controller.js
+++ b/lib/client/route_controller.js
@@ -19,7 +19,11 @@ _.extend(RouteController.prototype, {
     this['data'] = getOption('data');
     this['template'] = getOption('template') || (this.route && this.route.name);
     this['renderTemplates'] = getOption('renderTemplates');
-    this['waitOn'] = getOption('waitOn');
+    this['waitOn'] = []
+      .concat(RouterUtils.toArray(routerOptions.waitOn))
+      .concat(RouterUtils.toArray(routeOptions.waitOn))
+      .concat(RouterUtils.toArray(options.waitOn))
+      .concat(RouterUtils.toArray(this.waitOn));
   },
 
   /**
@@ -245,16 +249,18 @@ _.extend(RouteController.prototype, {
       return onReady.call(this);
 
     if (_.isFunction(handles)) {
-      handles = handles.call(self);
-      if (!handles)
-        throw new Error(
-          'It looks like your waitOn function is not returning anything!');
     }
-
-    if (!_.isArray(handles))
-      handles = [handles];
-
-    _.each(handles, function (handle) {
+    
+    // each handle could potentially be a function that returns handles, check
+    handles = _.map(handles, function(handle) {
+      return (_.isFunction(handle)) ? handle.call(self) : handle;
+    });
+    
+    if (!handles)
+      throw new Error(
+        'It looks like your waitOn function is not returning anything!');
+    
+    _.each(_.flatten(handles), function (handle) {
       if (!handle.ready())
         isReady = false;
     });


### PR DESCRIPTION
So now you can set handles on e.g. the router and a single controller and it'll wait on _both_ of them.

E.g.:

``` js
Router.configure({ 
  waitOn: function() { return Meteor.subscribe('something'); }
});

Router.map(function() {
  this.route('posts', {
   waitOn: function() { return Meteor.subscribe('somethingElse'); }
  });
```
