### PR TITLE
Controller `action` ignoring fix

### DIFF
--- a/lib/client/route_controller.js
+++ b/lib/client/route_controller.js
@@ -5,7 +5,7 @@ RouteController = Utils.extend(IronRouteController, {
     var self = this;
 
     var getOption = function (key) {
-      return Utils.pick(self.options[key], self[key]);
+      return Utils.pick(self[key], self.options[key]);
     };
 
     this.loadingTemplate = getOption('loadingTemplate');
@@ -13,7 +13,7 @@ RouteController = Utils.extend(IronRouteController, {
     this.data = getOption('data');
     this.template = getOption('template') || (this.route && this.route.name);
     this.yieldTemplates = getOption('yieldTemplates');
-    this.layoutTemplate = getOption('layoutTemplate');
+    this.layoutTemplate = getOption('layoutTemplate') || '__defaultLayout__';
     this.waitOn = []
       .concat(Utils.toArray(this.options.waitOn))
       .concat(Utils.toArray(this.waitOn));
@@ -51,7 +51,7 @@ RouteController = Utils.extend(IronRouteController, {
 
   yieldTemplates: null,
 
-  layoutTemplate: '__defaultLayout__',
+  layoutTemplate: null,
 
   /**
    * The default template to render

--- a/lib/route_controller.js
+++ b/lib/route_controller.js
@@ -4,15 +4,15 @@ IronRouteController = function (options) {
   options = this.options = options || {};
 
   var getOption = function (key) {
-    return Utils.pick(self.options[key], self[key]);
+    return Utils.pick(self[key], self.options[key]);
   };
 
-  this.router = options.router;
-  this.route = options.route;
-  this.path = options.path;
-  this.params = options.params || [];
-  this.where = options.where || 'client';
-  this.action = options.action || 'run';
+  this.router = getOption('router');
+  this.route = getOption('route');
+  this.path = getOption('path');
+  this.params = getOption('params') || [];
+  this.where = getOption('where') || 'client';
+  this.action = getOption('action') || 'run';
 
   this.hooks = {};
   this.hooks.before = Utils.toArray(options.before);


### PR DESCRIPTION
In dev now `action` of controller is being ignored: `'run'` is used instead.

``` js
Router.map(function () {

    this.route('someRoute', {
        path: '/some-path',
        controller: 'SomeController'
    });

});

SomeController = RouteController.extend({

    template: 'someTemplate'

    action: function () {
        console.log('SomeController action executed');
    }

});
```

There is nothing in console after navigating to `/some-path`.
