### PR TITLE
[server] Add cookie parser

### DIFF
--- a/lib/server/router.js
+++ b/lib/server/router.js
@@ -27,6 +27,7 @@ ServerRouter = Utils.extend(IronRouter, {
   start: function () {
     connectHandlers
       .use(connect.query())
+      .use(connect.cookieParser())
       .use(connect.bodyParser())
       .use(_.bind(this.onRequest, this));
   },


### PR DESCRIPTION
First off thanks for the great work on iron router.

This patch adds the cookieParser to the connectHandlers on the server.

One of the reason to add this is to be able to do something like:

``` coffeescript
#client
Deps.autorun () ->
  auth =
    id: null
    token: null
  if Meteor.userId()
    auth =
      'id': Meteor.userId()
      'token': localStorage.getItem("Meteor.loginToken")
  _.each auth, (val, key) ->
    document.cookie = ''+encodeURIComponent('meteor-auth-'+key)+'='+encodeURIComponent(val)+';path=/';
    return
  return
```

``` coffeescript
#server
class AuthController extends RouteController
  before: () ->
    return if @user()?
    @stopped = true
    @response.statusCode = 403
    @response.end() 
    return

  user: () ->
    userId = @request.cookies?['meteor-auth-id']
    userToken = @request.cookies?['meteor-auth-token']

    if userId? && userToken?
      user = Meteor.users.findOne({_id:userId, 'services.resume.loginTokens.token': userToken});
      return user if user?
    return null
```
