### PR TITLE
Fix the way Iron Router parses URLs to use slicing instead of splitting.

### DIFF
--- a/lib/route_path.js
+++ b/lib/route_path.js
@@ -116,7 +116,7 @@ RoutePath.prototype = {
     }
 
     path = decodeURI(path);
-    queryString = path.slice(path.indexOf(char) + 1);
+    queryString = path.slice(path.indexOf('?') + 1);
 
     if (queryString) {
       _.each(queryString.split('&'), function (paramString) {


### PR DESCRIPTION
The RoutePath.params(path) method was using "split" to extract the query string and to separate key from value in the individual components. This results in data being dropped out of individual values and some key, value pairs being dropped completely if they contain a '?' or a '='.

This pull request switches to using slicing instead of splitting to fix this problem.

Splitting on '&' to get an array of key, value pairs is appropriate and was not changed.
