### PR TITLE
Do not escape slashes in wildcard parameters.

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -203,7 +203,10 @@ Route.prototype = {
             }
 
             value = _.isFunction(value) ? value.call(params) : value;
-            return slash + encodeURIComponent(value);
+            var escapedValue = _.map(value.split('/'), function (segment) {
+              return encodeURIComponent(segment);
+            }).join('/');
+            return slash + escapedValue
           }
         )
         .replace(
@@ -216,7 +219,10 @@ Route.prototype = {
                 ' but the value of params at that index is undefined');
             }
 
-            return encodeURIComponent(params[wildCardCount++]);
+            var paramValue = params[wildCardCount++];
+            return _.map(paramValue.split('/'), function (segment) {
+              return encodeURIComponent(segment);
+            }).join('/');
           }
         );
 

--- a/test/route.js
+++ b/test/route.js
@@ -163,10 +163,25 @@ Tinytest.add('Route - resolve', function (test) {
   };
   test.equal(route.resolve(params, options), '/posts/1/?q=s#anchorTag');
 
+  route = new Route(Router, 'wildcard', {
+    path: paths.wildcard
+  });
+  params = ['some/file/path'];
+  test.equal(route.resolve(params), '/posts/some/file/path');
+
+  route = new Route(Router, 'namedWildcard', {
+    path: paths.namedWildcard
+  });
+  params = {
+    file: 'some/file/path'
+  }
+  test.equal(route.resolve(params), '/posts/some/file/path');
+
   // required parameter
   test.throws(function () {
     route.resolve({});
   });
+
 });
 
 Tinytest.add('Route - normalizePath', function (test) {


### PR DESCRIPTION
This applies to both named and unnamed parameters.
This fixes #198

Tests pass, but I had to comment out the `tests/client/router.js` 'ClientRouter - run with computations' test to get them to behave.
