### PR TITLE
Preliminary (and backwards-compatible) Meteor UI support

### DIFF
--- a/lib/client/default_layout.html
+++ b/lib/client/default_layout.html
@@ -1,3 +1,11 @@
-<template name="__defaultLayout__">
+<template name="__defaultSparkLayout__">
   {{yield}}
+</template>
+
+<template name="__defaultSpaceBarsLayout__">
+  {{> yield}}
+</template>
+
+<template name="__layoutHelper__">
+  {{> __layout}}
 </template>

--- a/lib/client/page_manager.js
+++ b/lib/client/page_manager.js
@@ -1,5 +1,6 @@
 var MAIN_YIELD = '__main__';
-var DEFAULT_LAYOUT = '__defaultLayout__';
+var DEFAULT_LAYOUT = typeof(UI) == 'object'
+  ? '__defaultSpaceBarsLayout__' : '__defaultSparkLayout__';
 
 var getTemplateFunction = function (template, defaultFn) {
   if (_.isFunction(template))
@@ -131,8 +132,12 @@ PageManager.prototype = {
         if (arguments.length < 2)
           key = null;
 
-        html = self._renderTemplate(key);
-        return new Handlebars.SafeString(html);
+        if (typeof(UI) == 'object') {
+          return self._renderTemplate(key);
+        } else {
+          html = self._renderTemplate(key);
+          return new Handlebars.SafeString(html);
+        }
       }
     };
   },
@@ -146,34 +151,42 @@ PageManager.prototype = {
     // setTemplate calls were for a yield region that exists.
     this._yields[key] = true;
 
-
-    return Spark.isolate(function () {
-      // grab the template function from Template or just make the template
-      // function return an empty string if no template found
-      var template = getTemplateFunction(self.yieldsToTemplates.get(key), function () {
-        return '';
-      });
-
-      var data = self.getData();
-      var helpers = self.helpers();
-      var dataContext = _.extend({}, data, helpers);
-
-      return template(dataContext);
+    // grab the template function from Template or just make the template
+    // function return an empty string if no template found
+    var template = getTemplateFunction(self.yieldsToTemplates.get(key), function () {
+      return '';
     });
+
+    var data = self.getData();
+    var helpers = self.helpers();
+    var dataContext = _.extend({}, data, helpers);
+
+    // Work with both Meteor UI and Spark, respectively
+    if (typeof(UI) == "object") {
+      return template.withData ? template.withData(dataContext) : null;
+    } else {
+      return Spark.isolate(function () {
+        return template(dataContext);
+      });      
+    }
   },
 
   renderLayout: function () {
     var self = this;
 
-    var html = Spark.isolate(function () {
-      var layout = getTemplateFunction(self.layout.get());
-      var data = self.data.get();
-      var helpers = self.helpers();
-      var dataContext = _.extend({}, data, helpers);
-      return layout(dataContext);
-    });
+    var data = self.data.get();
+    var helpers = self.helpers();
+    var dataContext = _.extend({}, data, helpers);
 
-    return html;
+    if (typeof(UI) == "object") {
+      dataContext.__layout = self.layout;
+      return Template.__layoutHelper__.withData(dataContext);
+    } else {
+      return Spark.isolate(function () {
+        var layout = getTemplateFunction(self.layout.get());
+        return layout(dataContext);
+      });
+    }
   },
 
   clearUnusedYields: function (usedYields) {
@@ -191,3 +204,14 @@ PageManager.prototype = {
     });
   }
 };
+
+/*
+ * With Spark, we could return a document fragment which reactively updated
+ * the layout was changed.  As best I can understand, this approach is
+ * deprecated with UI (we still do something similar to insert the main
+ * template, see ClientRouter.autoRender()), but with the new system
+ * we can more easily and powerfully return a full reactive template.
+ */
+Template['__layoutHelper__'].__layout = function() {
+  return Template[this.__layout.get()];
+}

--- a/lib/client/router.js
+++ b/lib/client/router.js
@@ -214,10 +214,15 @@ ClientRouter = Utils.extend(IronRouter, {
 
   autoRender: function () {
     var self = this;
-    var frag = Spark.render(function () {
-      return self.render();
-    });
-    document.body.appendChild(frag);
+    // Handle both Spark and Meteor UI (Spacebars) templates
+    if (typeof(UI) == 'object') {
+      UI.insert(UI.render(self.render()), document.body);
+    } else {
+      var frag = Spark.render(function () {
+        return self.render();
+      });
+      document.body.appendChild(frag);      
+    }
   },
 
 

--- a/package.js
+++ b/package.js
@@ -17,10 +17,10 @@ Package.on_use(function (api) {
   api.add_files('lib/route_controller.js', ['client', 'server']);
   api.add_files('lib/router.js', ['client', 'server']);
 
+  api.add_files('lib/client/default_layout.html', 'client');
   api.add_files('lib/client/location.js', 'client');
   api.add_files('lib/client/page_manager.js', 'client');
   api.add_files('lib/client/router.js', 'client');
-  api.add_files('lib/client/default_layout.html', 'client');
   api.add_files('lib/client/route_controller.js', 'client');
   api.add_files('lib/client/helpers.js', 'client');
 


### PR DESCRIPTION
This is a small patch which makes iron-router work with Meteor UI (without breaking support for Spark).

Ultimately, a lot of things can be implemented quite differently now.  This patch doesn't attempt to change the current underlying mechanisms, and indeed, function names and comments in the code refer solely to the Spark approach.  The main idea was a minimal patch to add backwards compatible support for Meteor UI, so that people can check out the preview release and still have routing support, and not break iron-router for existing releases.

Checked with:

``` bash
mrt --release template-engine-preview-1
mrt --release 0.6.6.2
```

Don't forget to change {{loginButtons}} and {{yield}} to {{> loginButtons}} and {{> yield}}, respectively.  I still need to look at named yields, but this is working great for my purposes so far and I think is a good starting point for now.
