### PR TITLE
Wrap reserved keyword class in quotes to fix IE8 Error.

### DIFF
--- a/lib/client/helpers.js
+++ b/lib/client/helpers.js
@@ -44,7 +44,7 @@ if (Handlebars) {
     var params = hash.params || this;
     var query = hash.query;
     var urlHash = hash.hash;
-    var cls = hash.class || '';
+    var cls = hash['class'] || '';
 
     var path = Router.path(route, params, {
       query: query,


### PR DESCRIPTION
The word class is a keyword in IE8. Using it throws Error(' Expected identifier').
