### PR TITLE
Fixed error when collecting parent hooks

### DIFF
--- a/lib/route_controller.js
+++ b/lib/route_controller.js
@@ -39,8 +39,9 @@ IronRouteController.prototype = {
     var collectInheritedHooks = function (ctor) {
       var hooks = [];
 
-      if (ctor.__super__)
+      if (ctor.__super__ && (ctor.prototype[hookName] !== ctor.__super__.constructor.prototype[hookName])) {
         hooks = hooks.concat(collectInheritedHooks(ctor.__super__.constructor));
+      }
       
       return ctor.prototype[hookName] ?
         hooks.concat(ctor.prototype[hookName]) : hooks;


### PR DESCRIPTION
Child controller inherits prototype's methods from the parent controller prototype.

So, if we have `Parent` controller

``` js
Parent.prototype.before = function () {
  console.log('parent.before');
};
```

and we create `Child` class inheriting from the `Parent` we will have prototype as follows:

``` js
Child.prototype.before = function () {
  console.log('parent.before');
};
```

Now when collecting hooks, the result hooks array will contain both functions instead one and it will cause double hook execution.

The solution is not copying Parent prototype to Child prototype or take that into account when hooks are run. I chose second solution because it's less invasive.

Before concatenating arrays of hooks with parent class, first I check if parent hooks are not the same as hooks in current class.

``` js
if (ctor.__super__ && (ctor.prototype[hookName] !== ctor.__super__.constructor.prototype[hookName])) {
  hooks = hooks.concat(collectInheritedHooks(ctor.__super__.constructor));
}
```
