### PR TITLE
Fixed error when collecting hooks

### DIFF
--- a/lib/route_controller.js
+++ b/lib/route_controller.js
@@ -42,7 +42,7 @@ IronRouteController.prototype = {
       if (ctor.__super__)
         hooks = hooks.concat(collectInheritedHooks(ctor.__super__.constructor));
       
-      return ctor.prototype[hookName] ?
+      return Utils.hasOwnProperty(ctor.prototype, hookName) ?
         hooks.concat(ctor.prototype[hookName]) : hooks;
     };
 


### PR DESCRIPTION
Child controller inherits prototype's methods from the parent controller prototype. When collecting hooks, the result hooks array will contain both functions instead one and it will cause double hook execution.

The problem is this line: https://github.com/EventedMind/iron-router/blob/dev/lib/route_controller.js#L45

``` js
return ctor.prototype[hookName] ? hooks.concat(ctor.prototype[hookName]) : hooks;
```

It checks, if given hook is in the given prototype but it will be true even, if the hook is not in the prototype. It's because it will look in the prototype of the parent class and so on. So, if we have three classes inheriting from each other:

`C` <- `B` <- `A` <- `RouteController`

and only `A` class will have `after` or `before` hook, it will still think that each one has given hook.

To deal with that, we have to explicitly check, if a given prototype has a hook by using `Utils.hasOwnProperty` function.

``` js
return Utils.hasOwnProperty(ctor.prototype, hookName) ? hooks.concat(ctor.prototype[hookName]) : hooks;
```
