### PR TITLE
Fix bug: encode, Where the URL has / in one of the values

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -204,9 +204,7 @@ Route.prototype = {
             }
 
             value = _.isFunction(value) ? value.call(params) : value;
-            var escapedValue = _.map(String(value).split('/'), function (segment) {
-              return encodeURIComponent(segment);
-            }).join('/');
+            var escapedValue = encodeURIComponent(value);
             return slash + escapedValue
           }
         )


### PR DESCRIPTION
I have a route `@route 'proposal', path: '/proposal/:id/:title?', controller: 'ProposalController'` in which the title might have a `/` in it. 
This will result in calling `Router.path` or `{{pathFor 'proposal'}}` an incorrect URL that the router is then unable to route. (it creates an extra / which the `/` in the title should actually be escaped).
The fix I propose fixes this issue. However, I assume I don't see the whole picture, I don't understand the case for splitting the value by / and escaping each segment on its own (the code I deleted and replaced). So probably my fix will create a regression somewhere else that I hadn't been able to realize...
Anyway, I think the bug I experience is a valid use case (that one of the elements has / and this / needs to be escaped). So if my suggested fix isn't right, there should be another...
thank you!
