### PR TITLE
Run hooks on the controller before route hooks.

### DIFF
--- a/lib/route_controller.js
+++ b/lib/route_controller.js
@@ -51,7 +51,7 @@ IronRouteController.prototype = {
     var globalHooks = 
       this.route ? this.router.getHooks(hookName, this.route.name) : [];
 
-    var allHooks = globalHooks.concat(routeHooks).concat(prototypeHooks).concat(more);
+    var allHooks = globalHooks.concat(prototypeHooks).concat(routeHooks).concat(more);
 
     for (var i = 0, hook; hook = allHooks[i]; i++) {
       if (this.stopped)


### PR DESCRIPTION
If a route has a controller, this will run the controllers hooks before the routes hooks instead of the other way around.

I'd say it is much more common to extend a controller by adding an additional before hook to run after the ones on the controller than adding a hook to run before the ones that are already defined. I put my basic stuff on the basecontroller (checking that the user is logged in, has accepted the terms of use etc.) and the special cases are functionality top of that. If I want to extend the before hooks for just one route I dont want to create a new controller that inherits from the basecontroller just for that. With this patch we can just put the extra before hook on the route.
