### PR TITLE
Change the way hash anchors are handled

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -143,8 +143,7 @@ Route.prototype = {
     var queryStringIndex = path.indexOf('?');
     path = ~queryStringIndex ? path.slice(0, queryStringIndex) : path;
 
-    var hashIndex = path.indexOf('#');
-    path = ~hashIndex ? path.slice(0, hashIndex) : path;
+    path = path.replace(/\/?#\/?/, '/')
 
     if (path.charAt(0) !== '/')
       path = '/' + path;

--- a/test/route.js
+++ b/test/route.js
@@ -183,7 +183,8 @@ Tinytest.add('Route - normalizePath', function (test) {
   test.equal(route.normalizePath('posts'), '/posts');
   test.equal(route.normalizePath(Meteor.absoluteUrl('posts')), '/posts');
   test.equal(route.normalizePath('/posts?q=s'), '/posts');
-  test.equal(route.normalizePath('/posts#anchorTag'), '/posts');
+  test.equal(route.normalizePath('/posts#anchorTag'), '/posts/anchorTag');
+  test.equal(route.normalizePath('/#/posts'), '/posts');
 });
 
 Tinytest.add('Route - getController', function (test) {


### PR DESCRIPTION
For issue #14

This probably isn't a backwards compatible change but it fixes an issue I was having in IE<10 caused by HTML5-History-API translating URLs of the form /some/path to /#/some/path and iron-router not paying attention to anything after the hash in a URL. I'm creating this pull request to more to add to the discussion already happening around IE<10 than to propose a solution.
