### PR TITLE
Added option to customise the IronLocation anchor selector 

### DIFF
--- a/lib/client/location.js
+++ b/lib/client/location.js
@@ -40,6 +40,21 @@ function onpopstate (e) {
 
 IronLocation = {};
 
+IronLocation.options = {
+  "linkSelector": 'a[href]'
+};
+
+IronLocation.configure = function(options){
+  if (this.isStarted){
+    IronLocation.unbindEvents();
+  }
+  _.extend(this.options, options);
+  
+  if(this.isStarted){
+    IronLocation.bindEvents();
+  }
+};
+
 IronLocation.origin = function () {
   return location.protocol + '//' + location.host;
 };
@@ -101,12 +116,21 @@ IronLocation.replaceState = function (state, title, url) {
     window.location = url;
 };
 
+IronLocation.bindEvents = function(){
+  $(window).on('popstate', onpopstate);
+  $(document).on('click', this.options.linkSelector, onclick);
+};
+
+IronLocation.unbindEvents = function(){
+  $(window).off('popstate', onpopstate);
+  $(window).off('click', this.options.linkSelector, onclick);
+};
+
 IronLocation.start = function () {
   if (this.isStarted)
     return;
 
-  $(window).on('popstate', onpopstate);
-  $(document).on('click', 'a[href]', onclick);
+  IronLocation.bindEvents();
   this.isStarted = true;
   
   // store the fact that this is the first route we hit.
@@ -120,8 +144,7 @@ IronLocation.start = function () {
 };
 
 IronLocation.stop = function () {
-  $(window).off('popstate', onpopstate);
-  $(window).off('click', 'a[href]', onclick);
+  IronLocation.unbindEvents();
   this.isStarted = false;
 };
 


### PR DESCRIPTION
Not necessarily a perfect PR, but I just wanted to float the idea of being able to customise the anchor selector for Iron Location.

Binding to `a[href]` on window doesn't suit every application - and interferes with other libraries like bootstrap tabs.

For example, I've customised my selector to `a[href][data-router="true"]`.

Another fix would be to ensure that the IronLocation handler / selector is always last in the list of event handlers- this would allow custom event handlers to call `e.preventDefault()` alleviating the need for this change.
