### PR TITLE
Additional argument to yield

### DIFF
--- a/lib/client/page_manager.js
+++ b/lib/client/page_manager.js
@@ -131,13 +131,13 @@ PageManager.prototype = {
         if (arguments.length < 2)
           key = null;
 
-        html = self._renderTemplate(key);
+        html = self._renderTemplate(key, options);
         return new Handlebars.SafeString(html);
       }
     };
   },
 
-  _renderTemplate: function (key) {
+  _renderTemplate: function (key, options) {
     var self = this;
 
     key = key || MAIN_YIELD;
@@ -156,7 +156,7 @@ PageManager.prototype = {
 
       var data = self.getData();
       var helpers = self.helpers();
-      var dataContext = _.extend({}, data, helpers);
+      var dataContext = _.extend({}, data, options, helpers);
 
       return template(dataContext);
     });


### PR DESCRIPTION
I'd like to call yield from within an each block, and use the current context when rendering the yield template.

A simple way would be to use yieldTemplates and pass the context to yield like this:

```
{{#each items}}
    {{../yield 'template' this}}
{{/each}}
```

The yield helper has an options argument, but it wasn't being passed along to the template. Any reason why not? Is there a better way to do this?

Thanks!
