### PR TITLE
Prevent running hooks from other routes

### DIFF
--- a/lib/client/router.js
+++ b/lib/client/router.js
@@ -117,6 +117,10 @@ ClientRouter = Utils.extend(IronRouter, {
           controller.runHooks('load');
         self._hasJustReloaded = false;
         
+        if (this.stopped){
+          return;
+        }
+        
         Deps.autorun(function () {
           controller.run();
         });


### PR DESCRIPTION
This had been solved in dev but hasn't made it to master.
