### PR TITLE
Fixes #306

### DIFF
--- a/lib/client/location.js
+++ b/lib/client/location.js
@@ -1,5 +1,4 @@
 var dep = new Deps.Dependency;
-var popped = false;
 // XXX: we have to store the state internally (rather than just calling out
 // to window.location) due to an android 2.3 bug. See:
 //   https://github.com/EventedMind/iron-router/issues/350
@@ -41,9 +40,6 @@ function onclick (e) {
 
 function onpopstate (e) {
   setState(e.state, null, location.pathname + location.search + location.hash);
-  
-  if (popped)
-    dep.changed();
 }
 
 IronLocation = {};
@@ -100,24 +96,23 @@ IronLocation.set = function (url, options) {
   else if (options.where === 'server')
     window.location = href;
   else if (options.replaceState)
-    IronLocation.replaceState(state, options.title, url);
+    IronLocation.replaceState(state, options.title, url, options.skipReactive);
   else
-    IronLocation.pushState(state, options.title, url);
-
-  if (options.skipReactive !== true)
-    dep.changed();
+    IronLocation.pushState(state, options.title, url, options.skipReactive);
 };
 
 // store the state for later access
-setState = function(newState, title, url) {
+setState = function(newState, title, url, skipReactive) {
+  if (!skipReactive && (currentState.path !== url || currentState.title !== title))
+    dep.changed();
+
   currentState = newState || {};
   currentState.path = url;
   currentState.title = title;
 }
 
-IronLocation.pushState = function (state, title, url) {
-  popped = true;
-  setState(state, title, url);
+IronLocation.pushState = function (state, title, url, skipReactive) {
+  setState(state, title, url, skipReactive);
   
   if (history.pushState)
     history.pushState(state, title, url);
@@ -125,9 +120,8 @@ IronLocation.pushState = function (state, title, url) {
     window.location = url;
 };
 
-IronLocation.replaceState = function (state, title, url) {
-  popped = true;
-  setState(state, title, url);
+IronLocation.replaceState = function (state, title, url, skipReactive) {
+  setState(state, title, url, skipReactive);
   
   if (history.replaceState)
     history.replaceState(state, title, url);


### PR DESCRIPTION
It seems that the `popped` variable was only there to detect state changes. The problem was that after page was reloaded the `popped` was automatically set to `false` (of course) which caused the `onpopstate` event to be practically ignored. One possible solution is to make the variable survive page reload or at least hot code push. Another option, which I considered the right one, is not to use `popped` variable at all, and only compare the current and previous states when the state is actually changed. I'm not sure if we should compare the `title` though.
