### PR TITLE
Update README.md (filters are properties now)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1010,10 +1010,10 @@ In Coffeescript we can use the language's native inheritance.
 
 ```coffeescript
 class @PostShowController extends RouteController
-  @before ->
+  before: ->
     # do some before stuff and note this is a class level method call '@'
 
-  @after ->
+  after: ->
     # call the class level after method using '@'
 
   layout: 'layout'


### PR DESCRIPTION
The coffeescript examples appear to be out of date. Iron Router appears to be no longer call a class level method, but calling a supplied property instead.

Cheers, I hope I got this right.
