### PR TITLE
don't attempt to call deprecated stop when calling redirect in a hook

### DIFF
--- a/lib/client/router.js
+++ b/lib/client/router.js
@@ -126,11 +126,7 @@ IronRouter = Utils.extend(IronRouter, {
       self._currentController._run();
     };
 
-    // if we already have a current controller let's stop it and then
-    // run the new one once the old controller is stopped. this will add
-    // the run function as an onInvalidate callback to the controller's
-    // computation. Otherwse, just run the new controller.
-    this._currentController ? this._currentController.stop(run) : run();
+    run();
 
     if (controller == this._currentController) {
       cb && cb(controller);


### PR DESCRIPTION
Fixes issue: #469
