### PR TITLE
Updated lib/server/router.js to fix an issue where server side routes stopped working with meteor 0.8 rc0

### DIFF
--- a/lib/server/router.js
+++ b/lib/server/router.js
@@ -59,7 +59,8 @@ IronRouter = Utils.extend(IronRouter, {
 
     this._currentController = controller;
     controller.runHooks('load');
-    controller.run();
+    //Fixes an issue where server side routes stop working with Meteor 0.8 rc0 blaze. Changed run() to _run();
+    controller._run();
 
     if (controller == this._currentController) {
       cb && cb(controller);


### PR DESCRIPTION
Note: There may be a pending issue where the http header value for x-ip-chain is not set when server side requests are made. 
