### PR TITLE
Allow query option to be a raw string

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -233,6 +233,8 @@ Route.prototype = {
 
         if (query && query.length)
           path = path + '/?' + query;
+      } else if (_.isString(query)) {
+        path = path + '/?' + query.replace(/^\?/, '');
       }
 
       if (hash) {


### PR DESCRIPTION
I think it is sometimes convenient to pass `query` option as a raw string. So why not allow this?
