### PR TITLE
Fix #330: Convert hash param to string

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -180,7 +180,7 @@ Route.prototype = {
     options = options || {};
     params = params || [];
     query = options.query;
-    hash = options.hash;
+    hash = options.hash && options.hash.toString();
 
     if (path instanceof RegExp) {
       throw new Error('Cannot currently resolve a regular expression path');

--- a/test/route.js
+++ b/test/route.js
@@ -286,6 +286,18 @@ Tinytest.add('Route - resolve', function (test) {
   };
   test.equal(route.resolve(params, options), '/posts/1/?q=s#anchorTag');
 
+  params = {
+    param: 1
+  };
+  options = {
+    query: {
+      q: 2
+    },
+    hash: 3
+  };
+  test.equal(route.resolve(params, options), '/posts/1/?q=2#3', 
+    'Must be able to resolve integer-formatted (non-string) params');
+
   test.equal(route.resolve(), null);
 
   route = new Route(Router, 'optional', {


### PR DESCRIPTION
I was able to reproduce #330 ([here's the repo](https://github.com/rdickert/ir330_repro)). In summary, if the template contains

```
<a href="{{pathFor 'customerList' hash=amountOwing}}"> View on customer list </a>
```

and `amountOwing` is an integer, the app will die with `TypeError: Object 3 has no method 'replace'`.

I added a failing test under `'Route - resolve'` and fixed it by calling `hash.toString()`.

This is my first PR to IR. Let me know if there is anything I should do differently - I'm learning here :-) I targeted the dev branch for this; not positive that's the correct one, so let me know.
