### PR TITLE
Running loading hook is required by wait api

### DIFF
--- a/lib/client/route_controller.js
+++ b/lib/client/route_controller.js
@@ -286,7 +286,7 @@ RouteController = Utils.extend(RouteController, {
 
       Deps.autorun(withNoStopsAllowed(function () {
         log('Call action');
-        self.runHooks('onBeforeAction', [], function (paused) {
+        self.runHooks('onBeforeAction', ['loading', ], function (paused) {
           if (!paused && !self.isStopped) {
             action.call(self);
 


### PR DESCRIPTION
BTW, what is the right place to run `dataNotFoundHook`?
