### PR TITLE
Set layout before each recomputed action

### DIFF
--- a/lib/client/route_controller.js
+++ b/lib/client/route_controller.js
@@ -85,7 +85,8 @@ RouteController = Utils.extend(RouteController, {
   },
 
   lookupLayoutTemplate: function () {
-    return this.lookupProperty('layoutTemplate');
+    // Return blaze-layout's bare layout if no layout is specified
+    return this.lookupProperty('layoutTemplate') || '_defaultLayout';
   },
 
   lookupTemplate: function () {
@@ -250,8 +251,6 @@ RouteController = Utils.extend(RouteController, {
       self._renderedRegions = [];
       self._waitList.clear();
 
-      self.layout(self.lookupLayoutTemplate());
-
       Deps.autorun(withNoStopsAllowed(function () {
         if (!self.router._hasJustReloaded)
           self.runHooks('onRun');
@@ -288,6 +287,13 @@ RouteController = Utils.extend(RouteController, {
         "You don't have an action named \"" + self.action + "\" defined on your RouteController");
 
       Deps.autorun(withNoStopsAllowed(function () {
+        // Set layout to configured template;
+        // it could have been modified in previously run hooks
+        // to display a login prompt, error message, etc.
+        // If no configured template is set, set layout to null
+        // to display the bare layout instead of something arbitrary.
+        self.layout(self.lookupLayoutTemplate());
+
         log('Call action');
         self.runHooks('onBeforeAction', [], function (paused) {
           if (!paused && !self.isStopped) {

--- a/test/client/route_controller.js
+++ b/test/client/route_controller.js
@@ -126,11 +126,11 @@ Tinytest.add('Client RouteController - _run order', function (test) {
   c._run();
 
   test.equal(calls, [
-    'layout',
     'onRun',
     'waitOn',
     'data',
     'onData',
+    'layout',
     'onBeforeAction',
     'action',
     'onAfterAction'


### PR DESCRIPTION
This PR resets the layout before running each action, ensuring that any layouts used for redirects in `onBeforeAction` hooks, etc. are not used in the default action, as discussed with @cmather in #600.

I've updated the tests and updated my app as well.

One quirk of this code is that the `_defaultLayout` has to be set if there is no layout set on the route; otherwise arbitrary layouts from other routes may be rendered. There could be a cleaner way to do this - I'm not sure how to add a test for it.
