### PR TITLE
enable automated testing on travis-ci.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - "0.10"
+before_install:
+  - "curl -L http://git.io/ejPSng | /bin/sh"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Iron Router
+# Iron Router [![Build Status](https://travis-ci.org/EventedMind/iron-router.png)](https://travis-ci.org/EventedMind/iron-router)
 
 A client and server side router designed specifically for Meteor.
 


### PR DESCRIPTION
Any package with Tinytest set up shouldn't pass on the ability to have automated tests be run for every commit and pull request! This makes it a lot easier to see when something has broken, as well as notifying if pull requests are working or not (at a minimum level.) It also adds a cool little build badge for the current status.

This package sets up @arunoda's https://github.com/arunoda/travis-ci-meteor-packages for this repo.

Before merging, either @cmather or @tmeasday will need to go to https://travis-ci.org/EventedMind/iron-router/ and turn on automated testing for this repository. For more information see the instructions in the readme for @arunoda's repo.
