### PR TITLE
Correcting outdated examples in docs.md

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -281,13 +281,13 @@ this:
 
 ```html
 <!-- given a context of {_id: 1} this will render '/posts/1?sort_by=created_at' -->
-<a href="{{pathFor 'postShow' sort_by=created_at}}">Post Show</a>
+<a href="{{pathFor 'postShow' query='sort_by=created_at'}}">Post Show</a>
 ```
 And you can pass a hash value using the Handlbars helper like this:
 
 ```html
 <!-- given a context of {_id: 1} this will render '/posts/1?sort_by=created_at#someAnchorTag' -->
-<a href="{{pathFor 'postShow' sort_by=created_at hash=someAnchorTag}}">Post Show</a>
+<a href="{{pathFor 'postShow' query='sort_by=created_at' hash='someAnchorTag'}}">Post Show</a>
 ```
 
 ### Changing routes programmatically
@@ -726,13 +726,13 @@ Router.map(function () {
   this.route('postShow', {
     path: '/posts/:_id',
 
-    onBeforeAction: function () {
+    onBeforeAction: function (pause) {
       if (!Meteor.user()) {
         // render the login template but keep the url in the browser the same
         this.render('login');
 
-        // stop the rest of the before hooks and the action function 
-        this.stop();
+        // pause the rest of the before hooks and the action function 
+        pause();
       }
     },
 


### PR DESCRIPTION
onBeforeAction no longer uses call to this.stop() but uses pause() instead.
pathFor helper no longer accepts query string in format key=value but instead takes query='key=value'
