### PR TITLE
Fix for IE9 omitting leading slash on pathname

### DIFF
--- a/lib/client/router.js
+++ b/lib/client/router.js
@@ -285,6 +285,9 @@ IronRouter = Utils.extend(IronRouter, {
     var href = el.href;
     var path = el.pathname + el.search + el.hash;
 
+    // ie9 omits the leading slash in pathname - so patch up if it's missing
+    path = path.replace(/(^\/?)/,"/");
+
     // we only want to handle clicks on links which:
     // - haven't been cancelled already
     if (e.isDefaultPrevented())


### PR DESCRIPTION
IE9 will omit the leading slash from el.pathname.  This eventually causes the go method to think it is a named route and go down the wrong logic path.  This should just add the leading slash if it does not already exist.
