### PR TITLE
don't render notFound template if route has no data option

### DIFF
--- a/lib/client/hooks.js
+++ b/lib/client/hooks.js
@@ -6,6 +6,10 @@ Router.hooks = {
     if (!this.ready())
       return;
 
+    // no data option was defined in route
+    if (!this.route.options.data)
+      return;
+
     if (data === null || typeof data === 'undefined') {
       tmpl = this.lookupProperty('notFoundTemplate');
 


### PR DESCRIPTION
This PR prevents the `notFound` template from always rendering on routes that have not specified a `data` option.
