### PR TITLE
Update route_controller.js

### DIFF
--- a/lib/server/route_controller.js
+++ b/lib/server/route_controller.js
@@ -40,8 +40,6 @@ RouteController = Utils.extend(RouteController, {
     } catch (e) {
       console.error(e.toString());
       this.response.end();
-    } finally {
-      this.response.end();
     }
   },
 


### PR DESCRIPTION
In order to ensure that streaming works in a server side route, we cannot call `this.response.end()` in the finally block as this is called regardless of whether there is an error or not. The below code will fail with large files (over ~800K) without this change:

```
this.route("poster", {
    where: "server"
    , path: "/post"
    , action: function() {

        var _self = this;

        var _write = fs.createWriteStream("/tmp/test.tar");
        _self.request.pipe(_write);

        var size = 0;

        _self.request.on("data", function(data) {
                size += data.length;
                console.log('Got chunk2 ' + data.length + ' total: ' + size);
        });

        _self.request.on("end", function() {
            console.log("ALL DONE");
            _self.response.end("Thanks");
        });

        _self.request.on("error", function(e) {
            console.log("ERROR: " + e.message);
        });

    }
});
```
