### PR TITLE
Fix for not resolved data

### DIFF
--- a/lib/client/hooks.js
+++ b/lib/client/hooks.js
@@ -13,7 +13,9 @@ Router.hooks = {
       return;
 
     var data = this.data();
-    if (data === null || typeof data === 'undefined') {
+
+    // Checking data.count allows us to specify Meteor.Collection instance in data function
+    if (data === null || typeof data === 'undefined' || (data.count && data.count() === 0)) {
       tmpl = this.lookupProperty('notFoundTemplate');
 
       if (tmpl) {

--- a/lib/client/route_controller.js
+++ b/lib/client/route_controller.js
@@ -19,6 +19,8 @@ RouteController = Utils.extend(RouteController, {
 
     this._waitList = new WaitList;
 
+    this._dataValue = this.lookupProperty('data');
+
     //XXX putting this back so people can access data by calling
     //this.data().
     this.data = bindData(this.lookupProperty('data'), this);


### PR DESCRIPTION
From lib/client/route_controller.js I resigned from writing
`this._dataValue = this.lookupProperty(‘data’) || {}` because we are
already checking whether data has been specified or not in hooks.js.

Issue #745
