### PR TITLE
Add auth hook

### DIFF
--- a/lib/client/hooks.js
+++ b/lib/client/hooks.js
@@ -59,7 +59,7 @@ Router.hooks = {
 
     if (!this.ready())
       return;
-    
+
     // there was never a data function defined at all
     // XXX: it would be more "correct" to call this.lookupProperty('data'),
     //   but it gets overridden by a data() in client/route_controller


### PR DESCRIPTION
I used @XpressiveCode's [iron-router-auth](/XpressiceCode/iron-router-auth) as inspiration and created an auth hook to use with onBeforeAction.

It's configurable globally and per route, using the `auth` namespace.
There is however one option that can only be set globally and that's `replaceState`

Activate hook globally

``` js
Router.onBeforeAction('auth', {except: ['signIn']});
```

Redirect to `signIn` route when user isn't logged in.

``` js
Router.configure({
  auth: 'signIn'
});

Router.configure({
  auth: {
    route: 'signIn',
    replaceState: false // Optional, defaults to true
  }
});

Router.map(function() {
  this.route('authNeededRoute', {
    auth: 'signIn',
    ...
  }
});

Router.map(function() {
  this.route('authNeededRoute', {
    auth: {
      route: 'signIn'
    },
    ...
  }
});

AuthNeededController = RouteController.extend({
  auth: 'signIn',
  // Activate hook per route
  onBeforeAction: 'auth',
  ...
});

AuthNeededController = RouteController.extend({
  auth: {
    route: 'signIn'
  }
  // Activate hook per route with another custom hook
  onBeforeAction: [
    'auth',
    function(pause) {
      // onBeforeAction hook
    }
  ],
  ...
});
```

Render `signIn` template in-place when user isn't logged in. (Configurable in same places as redirect examples)

``` js
Router.configure({
  auth: {
    layout: 'layout', // Optional
    template: 'signIn'
  }
});
```

If this isn't something you want in [iron-router](/EventedMind/iron-router) @cmather, I'll talk to @XpressiveCode and see if this might be the next iteration of [iron-router-auth](/XpressiveCode/iron-router-auth) otherwise it will become it's own package.
