### PR TITLE
Support routing to start below a subdirectory on the server

### DIFF
--- a/lib/client/router.js
+++ b/lib/client/router.js
@@ -174,6 +174,9 @@ IronRouter = Utils.extend(IronRouter, {
     
     // after the dispatch is complete, set the IronLocation
     // path and state which will update the browser's url.
+
+    // NOTE / SNEAKY: "path" gets updated later on in this function, *after* checking for it's route, to prefix the URL
+    // if the app is running in a subdirectory on the server
     done = function() {
       options = options || {};
       self._location.set(path, {
@@ -205,6 +208,8 @@ IronRouter = Utils.extend(IronRouter, {
       Utils.assert(route, 'No route found named ' + routeNameOrPath);
       path = route.path(params, options);
       controller = route.newController(path, options);
+      // update path to contain the subdirectory if the app is running in a subdirectory of the domain
+      path = __meteor_runtime_config__.ROOT_URL_PATH_PREFIX + path;
       self.run(controller, done);
     }
   },

--- a/lib/router.js
+++ b/lib/router.js
@@ -254,14 +254,14 @@ IronRouter.prototype = {
     var route = this.routes[routeName];
     Utils.warn(route,
      'You called Router.path for a route named ' + routeName + ' but that route doesn\'t seem to exist. Are you sure you created it?');
-    return route && route.path(params, options);
+    return route && (__meteor_runtime_config__.ROOT_URL_PATH_PREFIX + route.path(params, options));
   },
 
   url: function (routeName, params, options) {
     var route = this.routes[routeName];
     Utils.warn(route,
       'You called Router.url for a route named "' + routeName + '" but that route doesn\'t seem to exist. Are you sure you created it?');
-    return route && route.url(params, options);
+    return route && (__meteor_runtime_config__.ROOT_URL_PATH_PREFIX + route.url(params, options));
   },
 
   match: function (path) {
@@ -269,6 +269,18 @@ IronRouter.prototype = {
   },
     
   dispatch: function (path, options, cb) {
+    // check if the project is configured to run in a sub-path of a domain, eg. http://www.xyz.com/app1/
+    // if this is configured via the meteor environment variable ROOT_PATH (eg. ROOT_PATH='http://www.xyz.com/app1'), then
+    // __meteor_runtime_config__.ROOT_URL_PATH_PREFIX will be /app1 . On the client we need to remove that prefix from the path
+    // to still match the routes, but now starting below eg. /app1/firstRoute .
+    //
+    // this seems only to be required on the client. On the server side the URL seems to get cleaned by some other middleware beforhand?
+    var rootUrlPathPrefix = __meteor_runtime_config__.ROOT_URL_PATH_PREFIX;
+    if (Meteor.isClient && rootUrlPathPrefix) {
+        Utils.assert(path.substring(0, rootUrlPathPrefix.length) === rootUrlPathPrefix, "Unknown path prefix, expected: '" + rootUrlPathPrefix + "'");
+        path = path.substring(rootUrlPathPrefix.length);
+    }
+
     var route = this.match(path);
     
     if (! route)


### PR DESCRIPTION
Hello,

i created this patch to be able to run apps in a subdirectories of a domain.

Eg. if I want to have an app on

mydomain.com/beta ,

it's possible to tell meteor that via a the ROOT_URL environment variable like this:

ROOT_URL="http://mydomain.com/beta" mrt ,

but IronRouter didn't take that into account until now, meaning the URL mydomain.com/beta/hello would match the route "/beta/hello", instead of just "hello".

This means that one would have to either manually prepend the /subdirectory/on/the/server to each route, or invent some other scheme to dynamically create routes when the same app should be available ob different subdirectories on different servers for example.

Meteor provides a runtime variable, __meteor_runtime_config__.ROOT_URL_PATH_PREFIX , which contains the /subdirectory/on/the/server in which the app is running, both on the client and the server.

We therefore can use this variable to prepend it to created URLs in the router and remove it from the URLs when trying to match routes.

This then allows for multiple apps on different subdirectories.

Server side routes seem to work as well with this patch as Meteor takes into account the ROOT_URL_PATH_PREFIX when creating HTTP endpoints.

THE ONLY THING NOT SO NICE about this patch is that it will break existing routes containing the subdirectories in the routes.

So maybe this should be made configurable, or check against manually set ROOT_URL_PATH_PREFIXes manually set by logging a warning to the console? And maybe disable this functionality for these routes?

Please have a look at the patch, see if it makes sense, if I forgot anything obvious and if there's anything I could do to make it more palatable.

Thanks for the great work everybody and best wishes!

PS: I've submitted a pull request to CollectionFS too, if anyone needs to use that as well as IronRouter, check it out here: https://github.com/CollectionFS/Meteor-cfs-access-point/pull/8 or here: https://github.com/DanielDornhardt/Meteor-cfs-access-point/tree/supportSubdirectoriesOnDomain (at least until it's merged.)