### PR TITLE
Implement 'pass' function to skip to next matching route

### DIFF
--- a/lib/client/route_controller.js
+++ b/lib/client/route_controller.js
@@ -176,6 +176,10 @@ RouteController = Utils.extend(RouteController, {
     return this;
   },
 
+  pass: function () {
+    throw new RouteController.PassException()
+  },
+
   action: function () {
     this.render();
   },

--- a/lib/route_controller.js
+++ b/lib/route_controller.js
@@ -21,6 +21,8 @@ RouteController = function (router, route, options) {
   Utils.rewriteLegacyHooks(this);
 };
 
+RouteController.PassException = function() {};
+
 RouteController.prototype = {
   constructor: RouteController,
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -264,21 +264,32 @@ IronRouter.prototype = {
     return route && route.url(params, options);
   },
 
-  match: function (path) {
-    return _.find(this.routes, function(r) { return r.test(path); });
+  matches: function (path) {
+    return _.filter(this.routes, function(r) { return r.test(path); });
   },
     
   dispatch: function (path, options, cb) {
-    var route = this.match(path);
+    var matched = this.matches(path);
     
-    if (! route)
+    if (! matched.length)
       return this.onRouteNotFound(path, options);
     
-    if (route.where !== (Meteor.isClient ? 'client' : 'server'))
-      return this.onUnhandled(path, options);
-    
-    var controller = route.newController(path, options);
-    this.run(controller, cb);
+    for (var i = 0; i < matched.length; i++) {
+      if (matched[i].where !== (Meteor.isClient ? 'client' : 'server'))
+        return this.onUnhandled(path, options);
+
+      try {
+        var controller = matched[i].newController(path, options);
+        return this.run(controller, cb);
+      } catch(e) {
+        if (e instanceof RouteController.PassException)
+          continue;
+        else
+          throw e;
+      }
+    }
+
+    this.onRouteNotFound(path, options);
   },
 
   run: function (controller, cb) {

--- a/lib/server/route_controller.js
+++ b/lib/server/route_controller.js
@@ -45,6 +45,10 @@ RouteController = Utils.extend(RouteController, {
     }
   },
 
+  pass: function () {
+    this.next();
+  },
+
   action: function () {
     this.response.end();
   }


### PR DESCRIPTION
Hey @cmather, @tmeasday,

New feature: a route can tell iron-router to continue to the next matching route using the `pass()` method. When this method is invoked, iron-router will immediately stop processing the current matching route and invoke the next matching route. If no subsequent matching route is found, `onRouteNotFound()` is called.

Example:

``` javascript
  Router.map(function() {
    this.route('thisWillNeverRender', {
      path: '*',
      onBeforeAction: function() {
        this.pass();
      }
    });
    this.route('hello', {
      path: '/hello'
    });
  });
```

Requesting `/hello` will render the `hello` template. Requesting anything else will result in an `onRouteNotFound()`. `pass()` works on the server as well.

The idea for this feature was brought about because of a [`meteor-blog` issue](https://github.com/Differential/meteor-blog/issues/94), where we wanted the blog to handle any incoming slug to see if it was a blog post, and then pass the request on if it wasn't. 

WDYT?
