### PR TITLE
[Discussion] Implement 'pass' function to skip to next matching (middleware) route

### DIFF
--- a/lib/route_controller.js
+++ b/lib/route_controller.js
@@ -17,6 +17,8 @@ RouteController = Controller.extend({
   }
 });
 
+RouteController.PassException = function() {};
+
 /**
  * Returns an option value following an "options chain" which is this path:
  *

--- a/lib/route_controller_client.js
+++ b/lib/route_controller_client.js
@@ -139,6 +139,11 @@ RouteController.prototype._runRoute = function (route, url, done) {
   this.runHooks('onAfterAction', 'after');
 };
 
+RouteController.prototype.pass = function () {
+  this.next();
+  throw new RouteController.PassException();
+};
+
 /**
  * The default action for the controller simply renders the main template.
  */

--- a/lib/route_controller_server.js
+++ b/lib/route_controller_server.js
@@ -15,6 +15,10 @@ var MiddlewareStack = Iron.MiddlewareStack;
  */
 RouteController.prototype.init = function (options) {};
 
+RouteController.prototype.pass = function () {
+  this.next();
+};
+
 /**
  * Let this controller run a dispatch process. This function will be called
  * from the router. That way, any state associated with the dispatch can go on

--- a/lib/router_client.js
+++ b/lib/router_client.js
@@ -65,7 +65,7 @@ Router.prototype.dispatch = function (url, context, done) {
   this._currentController = controller;
 
   var result = controller.dispatch(self._stack, url, function (err) {
-    if (err)
+    if (err && !err instanceof RouteController.PassException)
       throw err;
     else {
       if (!controller.isHandled() && controller.willBeHandledOnServer()) {


### PR DESCRIPTION
New feature: a route can tell iron-router to continue to the next matching route using the `pass()` method. When this method is invoked, iron-router will immediately stop processing the current matching route and invoke the next matching route. If no subsequent matching route is found, `notFound` handlers are called as normal.

Example:

``` javascript
Router.route('/:whatever', function() {
  this.pass();
  this.render('thisWillNeverRender');
});

Router.route('/hello', function() {
  this.render('hello');
});
```

Requesting `/hello` will render the `hello` template. Requesting anything else will result in a `notFound`. `pass()` works on the server as well.

This was actually pretty easy once I understood the basic mechanics of the new middleware-based iron-router (nice work BTW!). But there is a lot of complexity there, so while I think this is right, please review I've done this correctly.

The idea for this feature was brought about because of a [`meteor-blog` issue](https://github.com/Differential/meteor-blog/issues/94), where we wanted the blog to handle any incoming slug to see if it was a blog post, and then pass the request on if it wasn't. 

WDYT?
