### PR TITLE
[Discussion] Add namespace to options

### DIFF
--- a/lib/route_controller.js
+++ b/lib/route_controller.js
@@ -51,25 +51,49 @@ RouteController.prototype.lookupOption = function (key) {
   // counterintuitive effect that if you define this.someprop = true on the
   // controller instance, and you have someprop defined as an option on your
   // Route, the route option will take precedence.
-  if (this.route && this.route.options && _.has(this.route.options, key))
-    return this.route.options[key];
+  var hasPath = function hasPath(obj, key) {
+    var key = key.split('.');
+    var i = -1, length = key.length;
+
+    while (++i < length && obj != null && _.isObject(obj)) {
+      if (key[i] in obj) {
+        obj = obj[key[i]];
+      } else {
+        return false;
+      }
+    }
+    return i === length;
+  };
+
+  var getPath = function getPath(obj, key) {
+    var key = key.split('.');
+    var i = -1, length = key.length;
+
+    while (++i < length && obj != null && _.isObject(obj)) {
+      obj = obj[key[i]];
+    }
+    return i === length ? obj : void 0;
+  };
+
+  if (this.route && this.route.options && hasPath(this.route.options, key))
+    return getPath(this.route.options, key);
 
   // this.options
-  if (_.has(this.options, key))
-    return this.options[key];
+  if (hasPath(this.options, key))
+    return getPath(this.options, key);
 
   // "this" object or its proto chain
-  if (typeof this[key] !== 'undefined')
-    return this[key];
+  if (hasPath(this, key))
+    return getPath(this, key);
 
   // see if we have the CurrentOptions dynamic variable set.
   var opts = CurrentOptions.get();
-  if (opts && _.has(opts, key))
-    return opts[key];
+  if (opts && hasPath(opts, key))
+    return getPath(opts, key);
 
   // this.router.options
-  if (this.router && this.router.options && _.has(this.router.options, key))
-    return this.router.options[key];
+  if (this.router && this.router.options && hasPath(this.router.options, key))
+    return getPath(this.router.options, key);
 };
 
 RouteController.prototype.configureFromUrl = function (url, context, options) {


### PR DESCRIPTION
This PR is dependent on PR #958.

If #958 isn't merged this PR need to change it's lookupOption order
to not change expected behaviour.

This PR adds namespaced options to hooks making it possible to use

this.lookupOption('template', 'loading') inside hooks to lookup options defined as this

``` js
Router.route('/', {
  loading: {
    template: 'loadingTemplate'
  }
});
```

Example

``` js
Router.hooks.test = function() {
  console.log('test: ' + this.lookupOption('message', 'test'));
  this.next();
};

Router.configure({
  simpleHook: {
    message: 'A simple before hook (gets overridden by options specified when adding hook)'
  }
});

Router.onBeforeAction(function() {
  console.log('simpleHook: ' + this.lookupOption('message', 'simpleHook'));
  console.log('simpleHook: ' + this.lookupOption('name'));
  this.next();
},
{
  only: 'home',
  namespace: 'simpleHook',
  message: 'A simple before hook (default message)'
});

Router.onBeforeAction('test', {
  message: 'Test hook message'
});

Router.route('/', {
  name: 'home',
  simpleHook: {
    message: 'A simple before hook (overrides options specified when adding hook)'
  }
});

// Don't know how this is working in the new version
// But before it wasn't good to try and override Router.configure
// options here. You would use a global ApplicationController instead of Router.configure
HomeController = RouteController.extend({
  simpleHook: {
    message: 'A simple before hook (overrides route options)'
  }
});
```

The only caveat I can think of right now is that you can't use 'except', 'namespace' or 'only' as options for the hook as these are used for restricting where the hook runs and which namespace the hook options uses.
