### PR TITLE
Use _.bind instead of Function.prototype.bind

### DIFF
--- a/lib/route_controller_client.js
+++ b/lib/route_controller_client.js
@@ -223,7 +223,7 @@ RouteController.prototype._runRoute = function (route, url, done) {
   // make sure the loading hook is the first one to run
   // before any of the other onBeforeAction hooks.
   if (useLoadingHook) {
-    stack.push(Iron.Router.hooks.loading.bind(self));
+    stack.push(_.bind(Iron.Router.hooks.loading, self));
   }
 
   var beforeHooks = this._collectHooks('onBeforeAction', 'before');


### PR DESCRIPTION
Because `Function.prototype.bind` may not be supported in some browsers (PhantomJS for example).
