### PR TITLE
Update Guide

### DIFF
--- a/Guide.md
+++ b/Guide.md
@@ -697,7 +697,7 @@ Router.route('/post/:_id', {
 
   // A declarative way of providing templates for each yield region
   // in the layout
-  yieldRegions: {
+  yieldTemplates: {
     'MyAside': {to: 'aside'},
     'MyFooter': {to: 'footer'}
   },


### PR DESCRIPTION
Change name of route option for yielding templates into specific regions from 'yieldRegions' to 'yieldTemplates' to match implementation
