### PR TITLE
Fix confusing route controller documentation

### DIFF
--- a/Guide.md
+++ b/Guide.md
@@ -1105,7 +1105,7 @@ providing a controller option.
 ```javascript
 Router.route('/post/:_id', {
   name: 'post.show',
-  controller: 'PostController'
+  controller: 'CustomController'
 });
 ```
 


### PR DESCRIPTION
The name of the "different" route controller, PostController, used in
the example for setting the controller option to Router.route({..}) is
actually the same as what would be looked up by default for a route
named "post". Therefore explicitly referring to PostController is
redundant.

Using the name, CustomController, that would otherwise have no relation
to a route named "post" demonstrates the intention more clearly and is
consistent with the name used in section, Route Specific Options:

https://github.com/EventedMind/iron-router/blame/7f3c355c0a3550c55a66501ba12a57367edd1ef4/Guide.md#L702