### PR TITLE
Fix #1126 - add check for default controller in Route.findControllerConstructor

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -112,6 +112,15 @@ Route.prototype.findControllerConstructor = function () {
   else if (typeof this.options.controller === 'string')
     return resolve(this.options.controller);
 
+  // is there a default route controller configured?
+  else if (Router.options.controller) {
+    if (typeof Router.options.controller === 'function')
+      return Router.options.controller;
+
+    else if (typeof Router.options.controller === 'string')
+      return resolve(Router.options.controller);
+  }
+
   // otherwise do we have a name? try to convert the name to a controller name
   // and resolve it to a value
   else if (name && (result = resolve(convert(name), {supressErrors: true})))


### PR DESCRIPTION
Default controller specified with `Router.configure` should be used when a route does not define one.