### PR TITLE
Explicitly extend the prototype

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -26,7 +26,7 @@ Route = function (path, fn, options) {
 
   // extend the route function with properties from this instance and its
   // prototype.
-  _.extend(route, this);
+  _.extend(route, this.constructor.prototype);
 
   // always good to have options
   options = route.options = options || {};

--- a/lib/router.js
+++ b/lib/router.js
@@ -35,7 +35,7 @@ Router = function (options) {
   this.configure.call(router, options);
 
   // add proto properties to the router function
-  _.extend(router, this);
+  _.extend(router, this.constructor.prototype);
 
   // let client and server side routing doing different things here
   this.init.call(router, options);


### PR DESCRIPTION
I've been working on [a solution](https://github.com/rclai/meteor-lodash-replace-underscore) to replace underscore with lodash in order to create a headstart for MDG to replace it in the future. In the process, I've noticed that the way you _.extend in these two constructors is incompatible with lodash and therefore breaks iron:router because lodash's extend doesn't carry over the prototypes. If you pull this, you would be creating a refactor path for underscore's incoming replacement, and this will still work with underscore.