### PR TITLE
Allow to use iron:router inside packages and fix #1383

### DIFF
--- a/package.js
+++ b/package.js
@@ -17,12 +17,13 @@ Package.on_use(function (api) {
   api.use('deps', 'client');
   api.use('ui');
   api.use('templating');
+  api.imply('templating');
 
   // for cloning
   api.use('ejson');
 
   // for dynamic scoping with environment variables
-  api.use('meteor')
+  api.use('meteor');
 
   // main namespace and utils
   api.use('iron:core@1.0.8');


### PR DESCRIPTION
Allow iron router to access `templating` package and correctly render templates when used inside packages.

See [#1383](https://github.com/iron-meteor/iron-router/issues/1383)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/iron-meteor/iron-router/1387)

<!-- Reviewable:end -->
