### PR TITLE
Namespace feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,17 +39,26 @@ Router.route('/restful', {where: 'server'})
 
 // Namespace
 Router.namespace('/admin', {
-  // Optional root route
+  // Optional namespace root route
   "/": "",
-  "posts": function() {
-    this.render('posts');
-  },
+  "posts": [
+    function() {
+      this.render('posts');
+    },
+    // Route options
+    {
+      layoutTemplate: 'anotherAdminLayout'
+    }
+  ],
   "comments": function() {
     this.render('comments');
   },
+  "something": "something"
 }, {
+  // Namespace options
   layoutTemplate: 'adminLayout'
 });
+
 ```
 
 ## Migrating from 0.9.4

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Router.route('/restful', {where: 'server'})
 
 // Namespace
 Router.namespace('/admin', {
-  // Optional root namespace
+  // Optional root route
   "/": "",
   "posts": function() {
     this.render('posts');

--- a/README.md
+++ b/README.md
@@ -37,6 +37,19 @@ Router.route('/restful', {where: 'server'})
     this.response.end('post request\n');
   });
 
+// Namespace
+Router.namespace('/admin', {
+  // Optional root namespace
+  "/": "",
+  "posts": function() {
+    this.render('posts');
+  },
+  "comments": function() {
+    this.render('comments');
+  },
+}, {
+  layoutTemplate: 'adminLayout'
+});
 ```
 
 ## Migrating from 0.9.4

--- a/lib/router.js
+++ b/lib/router.js
@@ -110,6 +110,36 @@ Router.prototype.use = function (path, fn, opts) {
 };
 */
 
+
+/**
+ *
+ * Combining routes with specific namespace
+ *
+ * @param {String} [namespace] Name of namespace
+ * @param {Object} [routes] Nested routes
+ * @param {Object} [opts] Shared options of namespace
+ * @return {IronRouter}
+ * @api public
+ *
+ */
+Router.prototype.namespace = function(namespace, routes, opts) {
+  _.each(routes, function(fn, path) {
+
+    // Create namespaced path or return root path of namespace
+    newPath = path == "/" ? namespace : namespace + "/" + path;
+
+    // If root route of namespace is declared but empty
+    // return namespace name instead
+    if(typeof fn === 'string' && newPath == namespace)
+      {
+        fn = namespace
+      }
+
+    // Initialize new route with namespace options
+    Router.route(newPath, fn, opts);
+  });
+}
+
 //XXX seems like we could put a params method on the route directly and make it reactive
 Router.prototype.route = function (path, fn, opts) {
   var typeOf = function (val) { return Object.prototype.toString.call(val); };

--- a/lib/router.js
+++ b/lib/router.js
@@ -123,7 +123,20 @@ Router.prototype.use = function (path, fn, opts) {
  *
  */
 Router.prototype.namespace = function(namespace, routes, opts) {
-  _.each(routes, function(fn, path) {
+  _.each(routes, function(behavior, path) {
+
+    // With route options
+    if (typeof behavior === 'object')
+      {
+        fn    = behavior[0];
+        opts  = behavior[1];
+        // TODO: Merge namespace options with route options?
+      }
+    // With namespace options
+    else
+      {
+        fn = behavior;
+      }
 
     // Create namespaced path or return root path of namespace
     newPath = path == "/" ? namespace : namespace + "/" + path;

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'iron:router',
   summary: 'Routing specifically designed for Meteor',
-  version: "1.0.10",
+  version: "1.0.9",
   git: "https://github.com/eventedmind/iron-router"
 });
 

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'iron:router',
   summary: 'Routing specifically designed for Meteor',
-  version: "1.0.9",
+  version: "1.0.10",
   git: "https://github.com/eventedmind/iron-router"
 });
 


### PR DESCRIPTION
Hello. I'd like to propose a implementation of namespaces (groups).

_Coffee syntax:_
```coffeescript
Router.namespace '/admin',
  {
    # Optional root route of namespace
    # Will search default namespaced "admin" template 
    "/"
    # Route with own options
    "posts":
      [
        -> @render 'posts',
        {
          layoutTemplate: 'anotherAdminLayout'
        }
      ]
    # Usual route
    "comments": ->
      @render 'comments'

    # "Empty route" will search the same template
    "something"
  },
  # Namespace options
  # Used by every routes inside namespace except routes with own options
  {
    layoutTemplate: 'adminLayout'
  }
```

Will create routes:

admin/
admin/posts
admin/comments
admin/something