### PR TITLE
Support `head` as an HTTP_METHOD

### DIFF
--- a/lib/http_methods.js
+++ b/lib/http_methods.js
@@ -3,5 +3,6 @@ HTTP_METHODS = [
   'post',
   'put',
   'delete',
-  'patch'
+  'patch',
+  'head'
 ];


### PR DESCRIPTION
Without using the `.get(...).put(...)` esque syntax, I get this error trying to define different methods for the same URL:

### Code:

```javascript
Router.route('/blah', function() {...}, {where: 'server', method: 'get', name: 'blah_get'});
Router.route('/blah', function() {...}, {where: 'server', method: 'head', name: 'blah_head'});
```

### Error:

```
Error: A route for the path "/blah" already exists by the name of "blah_head".
     at Iron.utils.assert (packages/iron:core/lib/iron_core.js:10:1)
     at Function.Router.route (packages/iron:router/lib/router.js:137:1)
```