### PR TITLE
add install info on top of file

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ A router that works on the server and the browser, designed specifically for <a 
 ## The Iron.Router Guide
 Detailed explanations of router features can be found in the [Guide](http://iron-meteor.github.io/iron-router/).
 
+##Installation
+
+```shell
+meteor add iron:router
+```
+
 ## Examples
 There are several examples in the [examples folder](examples).
 


### PR DESCRIPTION
It is not described how to add this package. It only shows the command on the local install instructions.
I think following most Readme file structures it should be listed in the beginning of the file.