### PR TITLE
RouteController reference typo

### DIFF
--- a/Guide.md
+++ b/Guide.md
@@ -706,7 +706,7 @@ Router.route('/post/:_id', {
 
   // If we want to provide a specific RouteController instead of an anonymous
   // one we can do that here. See the Route Controller section for more info.
-  controller: 'CustomController',
+  controller: CustomController,
 
   // If the template name is different from the route name you can specify it
   // explicitly here.
@@ -1113,7 +1113,7 @@ providing a controller option.
 ```javascript
 Router.route('/post/:_id', {
   name: 'post.show',
-  controller: 'CustomController'
+  controller: CustomController
 });
 ```
 
@@ -1162,7 +1162,7 @@ ApplicationController = RouteController.extend({
 
 Router.configure({
   // this will be the default controller
-  controller: 'ApplicationController'
+  controller: ApplicationController
 });
 
 // now we have a route for posts


### PR DESCRIPTION
It indeed requires passing the object of `RouteController` instead of its name, to controller property of each route. There should be a typo.
