### PR TITLE
Fixed a typo in Route.url()

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -171,7 +171,7 @@ Route.prototype.url = function (params, options) {
   var path = this.path(params, options);
   var host = (options && options.host) || Meteor.absoluteUrl();
 
-  if (host.charAt(host.length-1) === '/');
+  if (host.charAt(host.length-1) === '/')
     host = host.slice(0, host.length-1);
   return host + path;
 };


### PR DESCRIPTION
For example, calling
```javascript
Router.url('myRoute', {myOption: 123}, {host: 'http://www.example.com'});
```
would return something like
```javascript
"http://www.example.co/my-route/123"
```
instead of 
```javascript
"http://www.example.com/my-route/123"
```