### PR TITLE
Global error-handling requires preserving handler arity.

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -200,7 +200,7 @@ Router.prototype.createController = function (url, context) {
 
   context = context || {};
 
-  if (route)
+  if (route && route.createController)
     // let the route decide what controller to use
     controller = route.createController({layout: this._layout});
   else

--- a/lib/router.js
+++ b/lib/router.js
@@ -120,15 +120,22 @@ Router.prototype.route = function (path, fn, opts) {
     fn = opts.action;
   }
 
-  var route = new Route(path, fn, opts);
-
   opts = opts || {};
 
-  // don't mount the route
-  opts.mount = false;
+  // Given a 4-arity function, treat that as a global error handler and
+  // preserve is handler arity in order that dispatch finds it
+  if (typeof fn === 'function' && fn.length === 4) {
+    var route = this._stack.push(path, fn, opts);
+    var handler = route;
+  } else {
+    route = new Route(path, fn, opts);
 
-  // stack expects a function which is exactly what a new Route returns!
-  var handler = this._stack.push(path, route, opts);
+    // don't mount the route
+    opts.mount = false;
+
+    // stack expects a function which is exactly what a new Route returns!
+    handler = this._stack.push(path, route, opts);
+  }
 
   handler.route = route;
   route.handler = handler;


### PR DESCRIPTION
The changes here open the can of worms that is error handling, `Router.use` etc. :-)  I offer it more as food for thought than with an expectation that it's what's needed long-term.

This is the minimal change that allowed us to create a catchall route (as part of a REST API) that would convert thrown errors into a useful reply to the client.  The issue was that setting the route itself as the handler meant dispatch always saw a 3-arity function and so never invoked the error handler.  These changes work because the catchall route applies to all verbs.

Currently of course, the `route.get` et al add their handlers to the route's action stack.  While I see the benefits of that in relation to defining before- and after-action handlers, a 2D stack structure requires I hook a error handler on every route.

Granted I haven't spent much time with the client side -- yet :-) -- but, for me, it'd be cleaner to have just one linear stack of routes.  I understand we want handling a route to, in fact, walk a set of handlers in order to cover arbitrary sets of before- and after-hooks.  What that requires, though, is some way of `next`ing within the route or across routes (a la Express adding `next('route')` into the mix).
