### PR TITLE
Handle 404s correctly (Fixes #1055)

### DIFF
--- a/lib/router_client.js
+++ b/lib/router_client.js
@@ -184,7 +184,7 @@ Router.prototype.start = function () {
 
     if (current && current.isNotFound) {
       loc.cancelUrlChange();
-      window.location = loc.path;
+      return window.location = loc.path;
     }
 
     if (!current || (prevLocation && prevLocation.path !== loc.path)) {

--- a/lib/router_client.js
+++ b/lib/router_client.js
@@ -54,7 +54,7 @@ Router.prototype.createView = function () {
 Router.prototype.lookupNotFoundTemplate = function () {
   if (this.options.notFoundTemplate)
     return this.options.notFoundTemplate;
-  
+
   return (this.routes.length === 0) ? NO_ROUTES_TEMPLATE : DEFAULT_NOT_FOUND_TEMPLATE;
 };
 
@@ -102,8 +102,8 @@ Router.prototype.dispatch = function (url, context, done) {
       if (!controller.isHandled()) {
         // if we aren't at the initial state, we haven't yet given the server
         //   a true chance to handle this URL. We'll try.
-        //   if the server CAN'T handle the router, we'll be back, 
-        //   but as the very first route handled on the client, 
+        //   if the server CAN'T handle the router, we'll be back,
+        //   but as the very first route handled on the client,
         //   and so initial will be true.
         var state = Deps.nonreactive(function () { return controller.location.get().options.historyState; });
 
@@ -122,12 +122,16 @@ Router.prototype.dispatch = function (url, context, done) {
           this.render(notFoundTemplate, {data: {url: this.url}});
           this.renderRegions();
 
+          // Set isNotFound to true, so we know when to refresh the page and
+          // return the correct http status code when navigating to a new route.
+          this.isNotFound = true;
+
           // kind of janky but will work for now. this makes sure
           // that any downstream functions see that this route has been
           // handled so we don't get into an infinite loop with the
           // server.
           controller.isHandled = function () { return true; };
-        } 
+        }
 
         return done && done.call(controller);
       }
@@ -177,6 +181,11 @@ Router.prototype.start = function () {
     var loc = Iron.Location.get();
     var hash, pathname, search;
     var current = self._currentController;
+
+    if (current && current.isNotFound) {
+      loc.cancelUrlChange();
+      window.location = loc.path;
+    }
 
     if (!current || (prevLocation && prevLocation.path !== loc.path)) {
       controller = self.dispatch(loc.href, null, function onRouterStartDispatchCompleted (error) {

--- a/lib/router_server.js
+++ b/lib/router_server.js
@@ -70,23 +70,18 @@ Router.prototype.dispatch = function (url, context, done) {
     }
 
     // if there are no client or server handlers for this dispatch
-    // then send a 404.
-    // XXX we need a solution here for 404s on bad routes.
-    //     one solution might be to provide a custom 404 page in the public
-    //     folder. But we need a proper way to handle 404s for search engines.
-    // XXX might be a PR to Meteor to use an existing status code if it's set
+    // then set the statusCode to 404.
     if (!controller.isHandled() && !controller.willBeHandledOnClient()) {
-      return done();
-      /*
       res.statusCode = 404;
-      res.setHeader('Content-Type', 'text/html');
       msg = req.method + ' ' + req.originalUrl + ' not found.';
       console.error(msg);
-      if (req.method == 'HEAD')
+      if (req.method === 'HEAD')
+        res.setHeader('Content-Type', 'text/html');
         return res.end();
-      res.end(msg + '\n');
-      return;
-      */
+      // Allow Meteor to load the normal application so we can render
+      // a client-side 404 page.
+      if (done)
+        return done(err);
     }
 
     // if for some reason there was a server handler but no client handler

--- a/lib/router_server.js
+++ b/lib/router_server.js
@@ -44,7 +44,7 @@ Router.prototype.dispatch = function (url, context, done) {
     var msg;
 
     if (err) {
-      if (res.statusCode < 400) 
+      if (res.statusCode < 400)
         res.statusCode = 500;
 
       if (err.status)
@@ -75,9 +75,10 @@ Router.prototype.dispatch = function (url, context, done) {
       res.statusCode = 404;
       msg = req.method + ' ' + req.originalUrl + ' not found.';
       console.error(msg);
-      if (req.method === 'HEAD')
+      if (req.method === 'HEAD') {
         res.setHeader('Content-Type', 'text/html');
         return res.end();
+      }
       // Allow Meteor to load the normal application so we can render
       // a client-side 404 page.
       if (done)


### PR DESCRIPTION
This PR reinstates the code that sets Connect's `res.statusCode` to `404` when the route is not defined on the client or server (since a blocking issue with Meteor was fixed in meteor/meteor#5937). Instead of the previous behaviour of returning an error string, we now call `done()` to allow Meteor to render the app, and display the client-defined `notFoundTemplate`. This shouldn't be a breaking change because the most recent functionality was just to call `done()` which rendered the app without attempting to set the statusCode.

I've also slightly modified the handler for 'not found' routes on the client, so that Iron Router does a full page load when navigating to a new route. This is so that the 404 status code is replaced by the appropriate code (e.g. 200) when the new route loads, which may be important for search engine crawlers that render JavaScript - e.g. GoogleBot.

First IronRouter PR so any feedback appreciated. 

Fixes #1055 
