### PR TITLE
Add syntax highlight in the javascript code of the readme

### DIFF
--- a/Guide.md
+++ b/Guide.md
@@ -97,8 +97,8 @@ The `where: 'server'` option tells the Router this is a server side route.
   - [Using the Iron.Router.hooks Namespace](#using-the-ironrouterhooks-namespace)
   - [Available Hook Methods](#available-hook-methods)
 - [Route Controllers](#route-controllers)
-  - [Creating Route Controllers](#creating-route-controllers) 
-  - [Inheriting from Route Controllers](#inheriting-from-route-controllers) 
+  - [Creating Route Controllers](#creating-route-controllers)
+  - [Inheriting from Route Controllers](#inheriting-from-route-controllers)
   - [Accessing the Current Route Controller](#accessing-the-current-route-controller)
   - [Setting Reactive State Variables](#setting-reactive-state-variables)
   - [Getting Reactive State Variables](#getting-reactive-state-variables)
@@ -117,7 +117,7 @@ browser and close the connection.
 In some more modern Web apps you'll use a "client side" router like pagejs or
 Backbone router. These routers run in the browser, and let you navigate around
 an application without making trips to the server by taking advantage of browser
-HTML5 features like pushState or url hash fragments. 
+HTML5 features like pushState or url hash fragments.
 
 ### Client and Server
 Iron.Router runs on the client *and* the server. You can define a route that
@@ -180,7 +180,7 @@ using the `query` and `hash` properties of the `this.params` object.
 Router.route('/post/:_id', function () {
   var id = this.params._id;
   var query = this.params.query;
-  
+
   // query.q -> "s"
   var hash = this.params.hash; // "hashFrag"
 });
@@ -237,7 +237,7 @@ Router.route('/post/:_id', function () {
   });
 });
 ```
-If you wish to return access to more that one `Post` from the route, the 
+If you wish to return access to more that one `Post` from the route, the
 `data` option should return an object containing a cursor.
 
 ```javascript
@@ -311,7 +311,7 @@ Router.configure({
 
 ### Rendering Templates into Regions with JavaScript
 Inside of our route function we can tell the router which templates to render
-into each region. 
+into each region.
 
 ```handlebars
 <template name="Post">
@@ -342,11 +342,11 @@ Router.route('/post/:_id', function () {
   // {{> yield}}
   this.render('Post');
 
-  // render the PostAside template into the yield region named "aside" 
+  // render the PostAside template into the yield region named "aside"
   // {{> yield "aside"}}
   this.render('PostAside', {to: 'aside'});
 
-  // render the PostFooter template into the yield region named "footer" 
+  // render the PostFooter template into the yield region named "footer"
   // {{> yield "footer"}}
   this.render('PostFooter', {to: 'footer'});
 });
@@ -452,7 +452,7 @@ layout with some navigation links.
       <li>
         <a href="/">Home</a>
       </li>
-      
+
       <li>
         <a href="/one">Page One</a>
       </li>
@@ -506,7 +506,7 @@ Likewise, if the user clicks the `Page Two` link, the url in the browser will
 change to '/two' and the third route will run, rendering the 'PageTwo' template.
 
 Even though the url is changing in the browser, since these are client-side
-routes, the browser doesn't need to make requests to the server. 
+routes, the browser doesn't need to make requests to the server.
 
 ### Using JavaScript
 You can navigate to a given url, or even a route name, from JavaScript using the
@@ -749,7 +749,7 @@ Router.route('/post/:_id', {
   // a place to put your subscriptions
   subscriptions: function() {
     this.subscribe('items');
-    
+
     // add the subscription to the waitlist
     this.subscribe('item', this.params._id).wait();
   },
@@ -873,7 +873,7 @@ Router.route('/post/:_id', {
 });
 ```
 
-Your `subscriptions` function can return a single subscription handle (the result of `Meteor.subscribe`) or an array of them. The subscription(s) will be used to drive the `.ready()` state. 
+Your `subscriptions` function can return a single subscription handle (the result of `Meteor.subscribe`) or an array of them. The subscription(s) will be used to drive the `.ready()` state.
 
 You can also inherit subscriptions from the global router config or from a controller (see below).
 
@@ -884,7 +884,7 @@ Another alternative is to use `waitOn` instead of `subscribe`. This has the same
 Router.route('/post/:_id', {
   // this template will be rendered until the subscriptions are ready
   loadingTemplate: 'loading',
-  
+
   waitOn: function () {
     // return one handle, a function, or an array
     return Meteor.subscribe('post', this.params._id);
@@ -940,7 +940,6 @@ will see if there are any routes defined for that url, either on the server or
 on the client. If no routes are found, the server will send a 404 http status
 code to indicate no resource was found for the given url.
 
-
 ## Plugins
 Plugins are a way to reuse functionality in your router, either that you've
 built for your own applications, or from other package authors. There's even a
@@ -953,7 +952,7 @@ plugin and any options for the plugin.
 Router.plugin('dataNotFound', {notFoundTemplate: 'notFound'});
 ```
 
-This out-of-box plugin will automatically render the template named "notFound" 
+This out-of-box plugin will automatically render the template named "notFound"
 if the route's data is falsey (i.e. `! this.data()`).
 
 ### Applying Plugins to Specific Routes
@@ -963,13 +962,13 @@ explicitly don't want to run plugins designed for the client.
 
 ```javascript
 Router.plugin('dataNotFound', {
-  notFoundTemplate: 'NotFound', 
+  notFoundTemplate: 'NotFound',
   except: ['server.route']
   // or only: ['routeOne', 'routeTwo']
 });
 ```
 
-In the above example, the dataNotFound will be applied to all routes except the 
+In the above example, the dataNotFound will be applied to all routes except the
 route named 'server.route'.
 
 ### Creating Plugins
@@ -1060,7 +1059,7 @@ Router.onBeforeAction('customPackageHook');
 ```
 ### Available Hook Methods
 * **onRun**: Called when the route is first run. It is not called again if the
-  route reruns because of a computation invalidation. This makes it a good 
+  route reruns because of a computation invalidation. This makes it a good
   candidate for things like analytics where you want be sure the hook only runs once. Note that this hook *won't* run again if the route is reloaded via hot code push. You *must* call `this.next()` to continue calling the next function.
 
 * **onRerun**: Called if the route reruns because its computation is
@@ -1198,8 +1197,6 @@ PostController = ApplicationController.extend({
   layoutTemplate: 'PostLayout'
 });
 ```
-
-
 
 *NOTE: This is currently a bit tricky with Meteor since you can't precisely
 control file load order. You need to make sure parent RouteControllers are

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Iron Router should be reasonably backwards compatible, but there are a few requi
 
 `onRun` and `onBeforeAction` hooks now require you to call `this.next()`, and no longer take a `pause()` argument. So the default behaviour is reversed. For example, if you had:
 
-```
+```javascript
 Router.onBeforeAction(function(pause) {
   if (! Meteor.userId()) {
     this.render('login');
@@ -67,7 +67,7 @@ Router.onBeforeAction(function(pause) {
 
 You'll need to update it to
 
-```
+```javascript
 Router.onBeforeAction(function() {
   if (! Meteor.userId()) {
     this.render('login');
@@ -126,7 +126,7 @@ letters for each word and punctuation removed. If you would like to customize
 this behavior you can set your own converter function. For example, let's say
 you don't want any conversion. You can set the converter function like this:
 
-```
+```javascript
 Router.setTemplateNameConverter(function (str) { return str; });
 ```
 


### PR DESCRIPTION
In order to be more easy to read the example code.

Also, it removes some unnecessary spaces of the guide.

I just started a project with iron router, awesome work guys.

Thanks
