### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A router that works on the server and the browser, designed specifically for <a 
 ## The Iron.Router Guide
 Detailed explanations of router features can be found in the [Guide](http://iron-meteor.github.io/iron-router/).
 
-##Installation
+## Installation
 
 ```shell
 meteor add iron:router


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
