### PR TITLE
Meteor 3.0 compatibility

### DIFF
--- a/lib/route_controller_server.js
+++ b/lib/route_controller_server.js
@@ -1,7 +1,7 @@
 /*****************************************************************************/
 /* Imports */
 /*****************************************************************************/
-var Fiber = Npm.require('fibers');
+// var Fiber = Npm.require('fibers');
 var Controller = Iron.Controller;
 var Url = Iron.Url;
 var MiddlewareStack = Iron.MiddlewareStack;
@@ -24,9 +24,12 @@ RouteController.prototype.init = function (options) {};
  */
 RouteController.prototype.dispatch = function (stack, url, done) {
   var self = this;
-  Fiber(function () {
+
+  let go = Meteor.promisify(function (stack, self, done) {
     stack.dispatch(url, self, done);
-  }).run();
+    console.log('RouteController.prototype.dispatch');
+  }, self, true);
+  go(stack, self, done);
 };
 
 /**

--- a/lib/route_controller_server.js
+++ b/lib/route_controller_server.js
@@ -1,7 +1,6 @@
 /*****************************************************************************/
 /* Imports */
 /*****************************************************************************/
-// var Fiber = Npm.require('fibers');
 var Controller = Iron.Controller;
 var Url = Iron.Url;
 var MiddlewareStack = Iron.MiddlewareStack;
@@ -19,8 +18,7 @@ RouteController.prototype.init = function (options) {};
  * Let this controller run a dispatch process. This function will be called
  * from the router. That way, any state associated with the dispatch can go on
  * the controller instance. Note: no result returned from dispatch because its
- * run inside its own fiber. Might at some point move the fiber stuff to a
- * higher layer.
+ * used to be run inside its own fiber.
  */
 RouteController.prototype.dispatch = function (stack, url, done) {
   var self = this;

--- a/package.js
+++ b/package.js
@@ -9,12 +9,12 @@ Npm.depends({
   'body-parser': '1.12.4'
 });
 
-Package.on_use(function (api) {
-  api.versionsFrom('METEOR@0.9.2');
+Package.onUse(function (api) {
+  api.versionsFrom('3.0.2');
   // meteor dependencies
   api.use('underscore');
   api.use('webapp', 'server');
-  api.use('deps', 'client');
+  api.use('tracker', 'client');
   api.use('ui');
   api.use('templating');
 
@@ -43,34 +43,34 @@ Package.on_use(function (api) {
   // for RouteController which inherits from this
   api.use('iron:controller@1.0.12');
 
-  api.add_files('lib/current_options.js');
-  api.add_files('lib/http_methods.js');
-  api.add_files('lib/route_controller.js');
-  api.add_files('lib/route_controller_server.js', 'server');
-  api.add_files('lib/route_controller_client.js', 'client');
-  api.add_files('lib/route.js');
-  api.add_files('lib/router.js');
-  api.add_files('lib/hooks.js');
-  api.add_files('lib/helpers.js');
-  api.add_files('lib/router_client.js', 'client');
-  api.add_files('lib/body_parser_server.js', 'server');
-  api.add_files('lib/router_server.js', 'server');
-  api.add_files('lib/plugins.js');
-  api.add_files('lib/global_router.js');
-  api.add_files('lib/templates.html');
+  api.addFiles('lib/current_options.js');
+  api.addFiles('lib/http_methods.js');
+  api.addFiles('lib/route_controller.js');
+  api.addFiles('lib/route_controller_server.js', 'server');
+  api.addFiles('lib/route_controller_client.js', 'client');
+  api.addFiles('lib/route.js');
+  api.addFiles('lib/router.js');
+  api.addFiles('lib/hooks.js');
+  api.addFiles('lib/helpers.js');
+  api.addFiles('lib/router_client.js', 'client');
+  api.addFiles('lib/body_parser_server.js', 'server');
+  api.addFiles('lib/router_server.js', 'server');
+  api.addFiles('lib/plugins.js');
+  api.addFiles('lib/global_router.js');
+  api.addFiles('lib/templates.html');
 
   // symbol exports
   api.export('Router');
   api.export('RouteController');
 });
 
-Package.on_test(function (api) {
+Package.onTest(function (api) {
   api.use('iron:router');
   api.use('tinytest');
   api.use('test-helpers');
 
-  api.add_files('test/helpers.js');
-  api.add_files('test/route_test.js');
-  api.add_files('test/router_test.js');
-  api.add_files('test/route_controller_test.js');
+  api.addFiles('test/helpers.js');
+  api.addFiles('test/route_test.js');
+  api.addFiles('test/router_test.js');
+  api.addFiles('test/route_controller_test.js');
 });


### PR DESCRIPTION
Adapting iron-router to run in Meteor 3
Major changes :
- change dependency on Deps (obsolete) to Tracker
- replace Fiber wrapped call to dispatch to Promisify version
Minor changes
- package methods latest style (onUse, onTest, addFiles)